### PR TITLE
DOCS-76: DBInsert and DBUpdate syntax change

### DIFF
--- a/source/topics/appexample.rst
+++ b/source/topics/appexample.rst
@@ -54,7 +54,7 @@ Page structure is formed using the ``If(Condition){Body } .ElseIf(Condition){Bod
 Variables, Column Names and Language Resources
 ==============================================
 
-The unification of names of variables (on pages and in contracts), identifiers of interface page form fields, table column names and language resource labels can help significantly speed up the development of applications and make the program code easier to read. Let's suppose we want to pass parameters from an interface page to a contract. In this case, if the name of the username variable in the data section of the contract corresponds to the name of the username field of an interface page, which was passed to this contract, then you don't need to specify this ``username=username`` pair in the *Params* parameters of the *Button* function. Using the same names for variables and column names makes it easier to use the DBInsert and DBUpdate functions; for example, ``DBUpdate("member", $id, "username",$username)``. Using the same names for variables and language resource labels makes it easier to display the columns names of interface tables ``Table(mysrc,"ID=id,$username$=username")``.
+The unification of names of variables (on pages and in contracts), identifiers of interface page form fields, table column names and language resource labels can help significantly speed up the development of applications and make the program code easier to read. Let's suppose we want to pass parameters from an interface page to a contract. In this case, if the name of the username variable in the data section of the contract corresponds to the name of the username field of an interface page, which was passed to this contract, then you don't need to specify this ``username=username`` pair in the *Params* parameters of the *Button* function. Using the same names for variables and column names makes it easier to use the DBInsert and DBUpdate functions; for example, ``DBUpdate("member", $id, {username: $username})``. Using the same names for variables and language resource labels makes it easier to display the columns names of interface tables ``Table(mysrc,"ID=id,$username$=username")``.
 
 
 Access Rights
@@ -122,8 +122,8 @@ In order to prevent the execution of the TokenTransfer contract from within anot
         }
     }
     action {
-        DBUpdate("keys", $Sender_AccountId, "-amount", $Amount)
-        DBUpdate("keys", $Recipient_AccountId, "+amount", $Amount)
+        DBUpdate("keys", $Sender_AccountId, {"-amount": $Amount})
+        DBUpdate("keys", $Recipient_AccountId, {"+amount": $Amount})
     }
     }
 

--- a/source/topics/script.rst
+++ b/source/topics/script.rst
@@ -83,8 +83,8 @@ The action section contains the contract's main program code that retrieves addi
 .. code:: js
 
 	action {
-		DBUpdate("keys", $key_id,"-amount", $amount)
-		DBUpdate("keys", $recipient,"+amount,pub", $amount, $Pub)
+    DBUpdate("keys", $key_id, {"-amount": $amount})
+    DBUpdate("keys", $recipient, {"+amount": $amount,pub: $Pub})
 	}
 
 
@@ -166,7 +166,7 @@ Predefined variable ``$result`` is used to return a value from a nested contract
 
   contract my {
     data {
-        Name string
+        Name string 
         Amount money
     }
     func conditions {
@@ -176,8 +176,10 @@ Predefined variable ``$result`` is used to return a value from a nested contract
         $ownerId = 1232
     }
     func action {
-        DBUpdate("mytable", $ownerId, "name,amount", $Name, $Amount - 10 )
-        DBUpdate("mytable2", $citizen, "amount", 10 )
+        var amount money
+        amount = $Amount - 10
+        DBUpdate("mytable", $ownerId, {name: $Name,amount: amount})
+        DBUpdate("mytable2", $citizen, {amount: 10})
     }
   }
 
@@ -1395,7 +1397,7 @@ Example
 DBUpdateExt
 -----------
 
-The function updates columns in a record whose column has a specified value. The table must have an index for a specified column.
+The function updates columns in a record whose column matches the search condition.
 
 
 Syntax
@@ -1403,20 +1405,20 @@ Syntax
 
 .. code-block:: text
 
-    DBUpdateExt(tblname string, column string, value (int|string), params map)
+    DBUpdateExt(tblname string, where map, params map)
 
 
 .. describe:: tblname
 
     Name of the table in the database.
 
-.. describe:: column
+.. describe:: where
 
-    Name of the column by which the record will be searched for.
+    Search condition. 
 
-.. describe:: value
+    Examples: ``{name: "John"}``, ``{"id": {"$gte": 4}}``, ``{id: $key_id, ecosystem: $ecosystem_id}``.
 
-    Value for searching a record in a column.
+    For more information about search condition syntax, see :ref:`simvolio-DBFind`.
 
 .. describe:: params
 
@@ -1428,7 +1430,7 @@ Example
 
 .. code:: js
 
-    DBUpdateExt("mytable", "address", addr, {name: "John Smith", amount: 100})
+    DBUpdateExt("mytable", {id: $key_id, ecosystem: $ecosystem_id}, {name: "John Smith", amount: 100})
 
 
 .. _simvolio-DelColumn:

--- a/source/topics/script.rst
+++ b/source/topics/script.rst
@@ -88,6 +88,26 @@ The action section contains the contract's main program code that retrieves addi
 	}
 
 
+Price function
+--------------
+
+A contract can contain the **price** function. This function determines the extra fuel cost for executing the contract, in fuel units. 
+
+This function can return a value of *int* and *money* types. The returned value will be added to the cost of the contract execution and multiplied by **fuel_rate** coefficient.
+
+.. code:: js
+  
+  contract MyContract {
+    action {
+               DBUpdate("keys", $key_id, {"-amount": $amount})
+               DBUpdate("keys", $recipient, {"+amount": $amount,pub: $Pub})
+    }
+    func price int {
+         return 10000
+    }
+  }
+
+
 .. _simvolio-predefined-variables:
 
 Variables in the contract

--- a/source/topics/script.rst
+++ b/source/topics/script.rst
@@ -3431,7 +3431,9 @@ Example
 
 .. code:: js
 
-    DBInsert(`mytable`, `created_at`, BlockTime())
+    var mytime string
+    mytime = BlockTime()
+    DBInsert("mytable", myid, {time: mytime})
 
 
 .. _simvolio-DateTime:

--- a/source/topics/script.rst
+++ b/source/topics/script.rst
@@ -235,22 +235,6 @@ Functions do not allow direct possibilities to select, update, etc.. but they al
     to_timestamp(date_column) > now()
     date_initial < now() - 30 * interval '1 day'
 
-Consider the situation when we have a value in Unix format and we need to write it in a field of type *timestamp *. In this case, when listing fields, before the name of this column you need to specify **timestamp**.
-
-.. code:: js
-
-   DBInsert("mytable", "name,timestamp mytime", "John Smith", 146724678424 )
-
-If you have a string value of time and you need to write it in a field with the type *timestamp*, in this case, **timestamp** must be specified before the value itself.
-
-.. code:: js
-
-   DBInsert("mytable", "name,mytime", "John Smith", "timestamp 2017-05-20 00:00:00" )
-   var date string
-   date = "2017-05-20 00:00:00"
-   DBInsert("mytable", "name,mytime", "John Smith", "timestamp " + date )
-   DBInsert("mytable", "name,mytime", "John Smith", "timestamp " + $txtime )
-
 
 Following Simvolio functions work with date and time in SQL format:
 

--- a/source/topics/templates2.rst
+++ b/source/topics/templates2.rst
@@ -173,6 +173,8 @@ There is a number of functions that support the **PageParams** parameter, which 
 * ``PageParams: "hello=world"`` - the page will receive the hello parameter with world as value,
 * ``PageParams: "hello=#world#"`` - the page will receive the hello parameter with the value of the world variable.
 
+.. _protypo-Val:
+
 Additionally, the **Val** function allows for obtaining data from forms, which were specified in redirect. In this case,
 
 * ``PageParams: "hello=Val(world)"`` - the page will receive the hello parameter with the value of the world form element.

--- a/source/tutorials/app_tutorial.rst
+++ b/source/tutorials/app_tutorial.rst
@@ -306,7 +306,7 @@ Fill the ``action`` section. The single action is writing the message to the tab
 .. code-block:: js
 
     action {
-        DBInsert("apptable", "message", $Message)
+        DBInsert("apptable", {message: $Message})
     }
 
 
@@ -330,7 +330,7 @@ All |platform| contracts are constructed like this and always contain ``data``, 
             }
         }
         action {
-            DBInsert("apptable", "message", $Message)
+            DBInsert("apptable", {message: $Message})
         }
     }
 
@@ -417,7 +417,7 @@ Change the contract so that the author's ID and the timestamp are written to the
 .. code-block:: js
 
     action {
-        DBInsert("apptable", "message, author, timestamp", $Message, $key_id, $time)
+        DBInsert("apptable", {message: $Message, author: $key_id, timestamp: $time})
     }
 
 

--- a/source/tutorials/app_tutorial.rst
+++ b/source/tutorials/app_tutorial.rst
@@ -77,7 +77,7 @@ App components
 
     Tables hold information that is used by contracts and user interfaces.
 
-    Tables are regular database tables: you can query, update, and insert. These actions are performed with three :doc:`Simvolio language</topics/script>` functions: :func:`DBFind`, :func:`DBInsert`, and :func:`DBUpdate`.
+    Tables are regular database tables: you can query, update, and insert. These actions are performed with three :doc:`Simvolio language</topics/script>` functions: :ref:`simvolio-DBFind`, :ref:`simvolio-DBInsert`, and :ref:`simvolio-DBUpdate`.
 
 
 * User interfaces
@@ -475,7 +475,7 @@ Get data from the table
 
 At the moment, the page template does nothing. Change the code, so that the page displays data from the ``apptable`` table.
 
-#. To request data from a table, use the :func:`DBFind` function. 
+#. To request data from a table, use the :ref:`simvolio-DBFind` function. 
 
     The function call in the following exaple gets data from the ``apptable`` table, puts it into the ``src_table`` source, and orders it by the timestamp field. The ``src_table`` source is later used as a source of data for the table view on the page.
 
@@ -610,7 +610,7 @@ Sending messages
 
 Buttons in Protypo can execute contracts and open pages, depending on the arguments.
 
-The :func:`Button` function has two arguments for contracts:
+The :ref:`protypo-Button` function has two arguments for contracts:
 
 * ``Contract``
 
@@ -626,7 +626,7 @@ Form
 
 To send data to contracts, add a form to the app's page. This form must have an input field for the message, and a button that will activate the AppContract contract.
 
-Below is an example of such form. It is enclosed in its own :func:`Div`. Place it after the Div element that holds the table view. The :func:`Input` field of this form has a defined name, ``message_input``. This name is used by the button to send ``Message`` parameter value to the contract. Finally, :func:`Val` function is used to obtain the value of the input field.
+Below is an example of such form. It is enclosed in its own :ref:`protypo-Div`. Place it after the Div element that holds the table view. The :ref:`protypo-Input` field of this form has a defined name, ``message_input``. This name is used by the button to send ``Message`` parameter value to the contract. Finally, :ref:`Val <protypo-Val>` function is used to obtain the value of the input field.
 
 .. code-block:: default
 
@@ -678,7 +678,7 @@ This navigation requires two variables to store the table view state:
 Record count
 """"""""""""
 
-To calculate ``#record_count#``, modify the existing :func:`DBFind` function call. The variable specified in the ``.Count()`` call will store the record count.
+To calculate ``#record_count#``, modify the existing :ref:`protypo-DBFind` function call. The variable specified in the ``.Count()`` call will store the record count.
 
     .. code-block:: default
         
@@ -690,7 +690,7 @@ Table offset
 
 The table view offset must be passed to the page when it is opened. If ``#table_view_offset#`` is not passed, it is assumed to be ``0``.
 
-Add the following code to the top of the page template. This code uses conditionals. :func:`GetVar` function checks if the variable is set. :func:`SetVar` function sets the variable.
+Add the following code to the top of the page template. This code uses conditionals. :ref:`protypo-GetVar` function checks if the variable is set. :ref:`protypo-SetVar` function sets the variable.
 
     .. code-block:: default
 
@@ -699,7 +699,7 @@ Add the following code to the top of the page template. This code uses condition
             SetVar(table_view_offset, 0)
         }
 
-Modify the :func:`DBFind` function call again. This time it must use the new table view offset. 
+Modify the :ref:`protypo-DBFind` function call again. This time it must use the new table view offset. 
 
     .. code-block:: default
 
@@ -713,7 +713,7 @@ Buttons in Protypo can execute contracts and open pages, depending on the argume
 
 If you haven't already done so, open the page in the editor, and delete the existing *More* button.
 
-Afterwards, locate the :func:`Div` function call that defines the footer, ``Div(Class: panel-footer text-right)``. Add the button code to it.
+Afterwards, locate the :ref:`protypo-Div` function call that defines the footer, ``Div(Class: panel-footer text-right)``. Add the button code to it.
 
     .. code-block:: default
 


### PR DESCRIPTION
Fixes several syntax examples to use new DBInsert and DBUpdate syntax.